### PR TITLE
Discard user cancelation alert on non-english OS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,7 +151,7 @@ export function activate(context: vscode.ExtensionContext) {
                     editBuilder.replace(replaceTarget, outputFunction([color[0], color[1], color[2], selectedColorAlpha]));
                 });
             }).catch((err) => {
-                if (!err.message.includes('User canceled. (-128)')) {
+                if (!err.message.includes('(-128)')) {
                     console.log(err);
                     showErrorMessage(err.message);
                 }


### PR DESCRIPTION
The error message is being shown, translated, on non-english platforms, upon user cancelation.
To prevent this, one can match the error code only.