### PR TITLE
add support for hexadecimal int literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "vscode-mac-color-picker",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.0.1",
+			"name": "vscode-mac-color-picker",
+			"version": "1.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/color-convert": "^1.9.0",
@@ -1031,7 +1032,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
@@ -5451,10 +5451,8 @@
 			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
 			"dev": true,
 			"dependencies": {
-				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.1"
+				"neo-async": "^2.5.0"
 			},
 			"optionalDependencies": {
 				"chokidar": "^3.4.1",
@@ -5551,7 +5549,6 @@
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
 				"braces": "^2.3.2",
-				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,14 @@
 					"default": "hex",
 					"enum": [
 						"hex",
+						"hex int literal",
 						"rgb",
 						"hsl",
 						"hwb"
 					],
 					"enumDescriptions": [
 						"For example: #0000FF",
+						"For example: 0x0000FF",
 						"For example: rgb(0, 0, 255)",
 						"For example: hsl(240, 100%, 50%)",
 						"For example: hwb(240, 0%, 0%)"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ function toHexEnhanced(intLiteral: boolean) {
         }
     
         if (intLiteral) {
-            result = '0x' + result.substring(1);
+            result = '0x' + result.slice(1);
         }
     
         return result;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,20 +30,26 @@ function runScript(script: string): Promise<any> {
     });
 }
 
-function toHexEnhanced(color: colorString.Color) {
-    const config = vscode.workspace.getConfiguration('macColorPicker');
+function toHexEnhanced(intLiteral: boolean) {
+    return (color: colorString.Color) => {
+        const config = vscode.workspace.getConfiguration('macColorPicker');
 
-    let result = colorString.to.hex(color);
-
-    if (config.get('lowercaseHexColors')) {
-        result = result.toLowerCase();
-    }
-
-    if (config.get('shortHexColors')) {
-        result = shortenHex(result);
-    }
-
-    return result;
+        let result = colorString.to.hex(color);
+    
+        if (config.get('lowercaseHexColors')) {
+            result = result.toLowerCase();
+        }
+    
+        if (config.get('shortHexColors')) {
+            result = shortenHex(result);
+        }
+    
+        if (intLiteral) {
+            result = '0x' + result.substring(1);
+        }
+    
+        return result;
+    };
 }
 
 function getDefaultColorModel(): ColorModel {
@@ -54,7 +60,7 @@ function getDefaultColorModel(): ColorModel {
 			return 'hsl';
 		case 'hwb':
             return 'hwb';
-        default: // hex, rgb -> rgb
+        default: // hex, 'hex int literal', rgb -> rgb
             return 'rgb';
 	}
 }
@@ -69,8 +75,12 @@ function getDefaultOutputFunction(): Function {
 			return colorString.to.hsl;
 		case 'hwb':
             return colorString.to.hwb;
+
+        case 'hex int literal': //'hex int literal' -> rgb
+            return toHexEnhanced(true);
+
 		default: // hex -> rgb
-			return toHexEnhanced;
+			return toHexEnhanced(false);
 	}
 }
 
@@ -109,7 +119,14 @@ export function activate(context: vscode.ExtensionContext) {
             // Loop over both selections to see if one of them contains a color recognizable by colorString
             for (const selection of selections) {
                 if (selection !== undefined) {
-                    const selectedText = editor.document.getText(selection).trim();
+                    let selectedText = editor.document.getText(selection).trim();
+
+                    const isIntLiteral = selectedText.startsWith('0x');
+
+                    if (isIntLiteral) {
+                        selectedText = '#' + selectedText.slice(2);
+                    }
+
                     const selectedColorDescriptor = colorString.get(selectedText);
 
                     if (selectedColorDescriptor === null) {
@@ -134,7 +151,7 @@ export function activate(context: vscode.ExtensionContext) {
                             if (selectedText.startsWith('rgb')) {
                                 outputFunction = colorString.to.rgb;
                             } else {
-                                outputFunction = toHexEnhanced;
+                                outputFunction = toHexEnhanced(isIntLiteral);
                             }
                         } else {
                             outputFunction = colorString.to[selectedColorModel];

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+const color = 0xff0000;


### PR DESCRIPTION
First, thank you for your extension!

I use it to pick colors in Phaser JS game engine, where colors are written as numbers in the JavaScript source code. As in JS (and many other programming languages) hexadecimal int literals start with `0x`, not `#`, I've added such color notation for this use case