### PR TITLE
Added support for colors with values from 0 to 1, useful in shaders, like vec3() or vec4()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ If a color is selected, the extension will pass it into the color picker. The fo
     - `hsl(360, 100%, 50%)`
     - `hsla(360, 100%, 50%, 0.5)` *(see note below)*
 - hwb() notation, for example: `hwb(60, 3%, 60%)`
+- vec3() / vec4() notation, for example:
+    - `vec3(0.1, 0.2, 0.3)`
+    - `vec4(0.1, 0.2, 0.3, 0.4)`
 
 **Note:** the color picker currently cannot change the alpha channel value (opacity). This may change in the future releases.
 
@@ -62,7 +65,7 @@ If you have a problem or a suggestion, please open an issue on [GitHub](https://
 - Josh Junon ([@Qix-](https://github.com/Qix-)) for [color-string](https://github.com/Qix-/color-string) and [color-convert](https://github.com/Qix-/color-convert).
 - Dustin Specker ([@dustinspecker](https://github.com/dustinspecker/)) for [shorten-css-hex](https://github.com/dustinspecker/shorten-css-hex).
 
-Contributors: [@azerum](https://github.com/azerum), [@7ute](https://github.com/7ute).
+Contributors: [@azerum](https://github.com/azerum), [@7ute](https://github.com/7ute), [@lerg](https://github.com/lerg).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
 				"ts-loader": "^9.3.1",
 				"ts-node": "^10.9.1",
 				"typescript": "^4.7.4",
-				"webpack": "^5.74.0",
+				"webpack": "^5.89.0",
 				"webpack-cli": "^4.10.0"
 			},
 			"engines": {
-				"vscode": "^1.49.0"
+				"vscode": "^1.69.2"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -91,9 +91,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
@@ -123,9 +123,9 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+			"integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -249,9 +249,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "0.0.51",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
@@ -457,148 +457,148 @@
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+			"integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+			"integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+			"integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+			"integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-opt": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6",
+				"@webassemblyjs/wast-printer": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+			"integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+			"integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+			"integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+			"integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -651,9 +651,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -663,9 +663,9 @@
 			}
 		},
 		"node_modules/acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -1020,9 +1020,9 @@
 			"dev": true
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+			"integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -1045,9 +1045,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
 		},
 		"node_modules/escalade": {
@@ -2212,9 +2212,9 @@
 			]
 		},
 		"node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
@@ -2245,9 +2245,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
@@ -2381,13 +2381,13 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
+			"integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -2399,16 +2399,16 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-			"integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+			"version": "5.3.9",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+			"integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.16.8"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -2430,6 +2430,16 @@
 				"uglify-js": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/text-table": {
@@ -2631,22 +2641,22 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.74.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.0",
+				"@webassemblyjs/ast": "^1.11.5",
+				"@webassemblyjs/wasm-edit": "^1.11.5",
+				"@webassemblyjs/wasm-parser": "^1.11.5",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
+				"acorn-import-assertions": "^1.9.0",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.15.0",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -2655,9 +2665,9 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
+				"terser-webpack-plugin": "^5.3.7",
 				"watchpack": "^2.4.0",
 				"webpack-sources": "^3.2.3"
 			},
@@ -2858,9 +2868,9 @@
 			"dev": true
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
@@ -2881,9 +2891,9 @@
 			"dev": true
 		},
 		"@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+			"integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -2998,9 +3008,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.51",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"@types/json-schema": {
@@ -3117,148 +3127,148 @@
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+			"integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+			"integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+			"integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+			"integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-opt": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6",
+				"@webassemblyjs/wast-printer": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+			"integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+			"integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+			"integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+			"integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -3298,15 +3308,15 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true
 		},
 		"acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -3569,9 +3579,9 @@
 			"dev": true
 		},
 		"enhanced-resolve": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+			"integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -3585,9 +3595,9 @@
 			"dev": true
 		},
 		"es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
 		},
 		"escalade": {
@@ -4447,9 +4457,9 @@
 			"dev": true
 		},
 		"schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.8",
@@ -4467,9 +4477,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -4567,28 +4577,40 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
+			"integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-			"integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+			"version": "5.3.9",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+			"integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.16.8"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.20",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+					"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.1.0",
+						"@jridgewell/sourcemap-codec": "^1.4.14"
+					}
+				}
 			}
 		},
 		"text-table": {
@@ -4717,22 +4739,22 @@
 			}
 		},
 		"webpack": {
-			"version": "5.74.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.0",
+				"@webassemblyjs/ast": "^1.11.5",
+				"@webassemblyjs/wasm-edit": "^1.11.5",
+				"@webassemblyjs/wasm-parser": "^1.11.5",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
+				"acorn-import-assertions": "^1.9.0",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.15.0",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -4741,9 +4763,9 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
+				"terser-webpack-plugin": "^5.3.7",
 				"watchpack": "^2.4.0",
 				"webpack-sources": "^3.2.3"
 			}

--- a/package.json
+++ b/package.json
@@ -56,13 +56,15 @@
 						"hex",
 						"rgb",
 						"hsl",
-						"hwb"
+						"hwb",
+						"vec"
 					],
 					"enumDescriptions": [
 						"For example: #0000FF",
 						"For example: rgb(0, 0, 255)",
 						"For example: hsl(240, 100%, 50%)",
-						"For example: hwb(240, 0%, 0%)"
+						"For example: hwb(240, 0%, 0%)",
+						"For example: vec3(0.5, 0.75, 1.0)"
 					]
 				},
 				"macColorPicker.lowercaseHexColors": {
@@ -100,7 +102,7 @@
 		"ts-loader": "^9.3.1",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.7.4",
-		"webpack": "^5.74.0",
+		"webpack": "^5.89.0",
 		"webpack-cli": "^4.10.0"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as colorString from 'color-string';
 import * as colorConvert from 'color-convert';
 import * as applescript from 'applescript';
 
-type ColorModel = 'rgb' | 'hsl' | 'hwb';
+type ColorModel = 'rgb' | 'hsl' | 'hwb' | 'vec';
 type AppleColor = [number, number, number];
 
 function showInformationMessage(msg: string): void {
@@ -30,24 +30,83 @@ function runScript(script: string): Promise<any> {
     });
 }
 
+function colorStringExtGetVec(text: string): number[] | null {
+    let vec = /^vec[34]\(\s*([+-]?[\d\.]+)\s*,?\s*([+-]?[\d\.]+)\s*,?\s*([+-]?[\d\.]+)\s*(?:[,|\/]\s*([+-]?[\d\.]+)\s*)?\)$/;
+    var rgb = [0, 0, 0];
+    let match;
+    let i;
+    if (match = text.match(vec)) {
+        for (i = 0; i < 3; i++) {
+            rgb[i] = parseFloat(match[i + 1]);
+        }
+        if (match[4]) {
+            rgb[3] = parseFloat(match[4]);
+        }
+    } else {
+        return null;
+    }
+    return rgb;
+}
+
+function floatToFixedTrim(value: number): string {
+    let s = value.toFixed(4);
+    while (s[s.length - 1] === '0') {
+        s = s.slice(0, -1)
+        if (s[s.length - 1] !== '0' || s[s.length - 2] === '.') break;
+    }
+    return s;
+}
+
+let swizzle = require('simple-swizzle');
+let colorStringExt = {
+    get: function(text: string) {
+        let model: ColorModel = 'vec';
+        let val = colorStringExtGetVec(text);
+        if (!val) {
+            return null;
+        }
+        return {model: model, value: val};
+    },
+    to: {
+        vec: function (): string {
+            let rgba = swizzle(arguments);
+
+            return rgba.length < 4 || rgba[3] === null
+                ? 'vec3(' + floatToFixedTrim(rgba[0]) + ', ' + floatToFixedTrim(rgba[1]) + ', ' + floatToFixedTrim(rgba[2]) + ')'
+                : 'vec4(' + floatToFixedTrim(rgba[0]) + ', ' + floatToFixedTrim(rgba[1]) + ', ' + floatToFixedTrim(rgba[2]) + ', ' + floatToFixedTrim(rgba[3]) + ')';
+        }
+    }
+};
+
+function colorConvertVecApple(value: number[]): AppleColor {
+    let apple_color: AppleColor;
+    apple_color = [value[0] * 65535, value[1] * 65535, value[2] * 65535];
+    return apple_color;
+}
+
+function colorConvertAppleVec(value: AppleColor): number[] {
+    let color = [value[0] / 65535, value[1] / 65535, value[2] / 65535];
+    return color;
+}
+
 function toHexEnhanced(intLiteral: boolean) {
     return (color: colorString.Color) => {
         const config = vscode.workspace.getConfiguration('macColorPicker');
 
         let result = colorString.to.hex(color);
-    
+
         if (config.get('lowercaseHexColors')) {
             result = result.toLowerCase();
         }
-    
+
         if (config.get('shortHexColors')) {
             result = shortenHex(result);
         }
-    
+
         if (intLiteral) {
             result = '0x' + result.slice(1);
         }
-    
+
         return result;
     };
 }
@@ -56,32 +115,36 @@ function getDefaultColorModel(): ColorModel {
     const config = vscode.workspace.getConfiguration('macColorPicker');
 
     switch (config.get('defaultColorNotation')) {
-		case 'hsl':
-			return 'hsl';
-		case 'hwb':
+        case 'hsl':
+            return 'hsl';
+        case 'hwb':
             return 'hwb';
+        case 'vec':
+            return 'vec';
         default: // hex, 'hex int literal', rgb -> rgb
             return 'rgb';
-	}
+    }
 }
 
 function getDefaultOutputFunction(): Function {
     const config = vscode.workspace.getConfiguration('macColorPicker');
 
     switch (config.get('defaultColorNotation')) {
-		case 'rgb':
-			return colorString.to.rgb;
-		case 'hsl':
-			return colorString.to.hsl;
-		case 'hwb':
+        case 'rgb':
+            return colorString.to.rgb;
+        case 'hsl':
+            return colorString.to.hsl;
+        case 'hwb':
             return colorString.to.hwb;
+        case 'vec':
+            return colorStringExt.to.vec;
 
         case 'hex int literal': //'hex int literal' -> rgb
             return toHexEnhanced(true);
 
-		default: // hex -> rgb
-			return toHexEnhanced(false);
-	}
+        default: // hex -> rgb
+            return toHexEnhanced(false);
+    }
 }
 
 // Copyright (c) 2015 Dustin Specker — MIT License
@@ -108,7 +171,7 @@ export function activate(context: vscode.ExtensionContext) {
             let replaceTarget : vscode.Range | vscode.Selection = editor.selection;
             let selectedColorModel: ColorModel = getDefaultColorModel();
             let selectedColorValue: AppleColor = [65535, 0, 65535]; // UnrealEd :)
-            let selectedColorAlpha: number = 1;
+            let selectedColorAlpha: number | null = null;
             let outputFunction : Function = getDefaultOutputFunction();
 
             const selections = [
@@ -120,6 +183,28 @@ export function activate(context: vscode.ExtensionContext) {
             for (const selection of selections) {
                 if (selection !== undefined) {
                     let selectedText = editor.document.getText(selection).trim();
+                    if (selectedText.startsWith('vec')) {
+                        const selectedColorDescriptor = colorStringExt.get(selectedText);
+                        if (selectedColorDescriptor === null) {
+                            return showInformationMessage('Please select the entire color expression.');
+                        } else {
+                            replaceTarget = selection;
+                            selectedColorModel = selectedColorDescriptor.model;
+                            selectedColorValue = colorConvertVecApple([
+                                selectedColorDescriptor.value[0],
+                                selectedColorDescriptor.value[1],
+                                selectedColorDescriptor.value[2]
+                            ]);
+                            if (selectedColorDescriptor.value[3]) {
+                                selectedColorAlpha = selectedColorDescriptor.value[3];
+                            } else {
+                                selectedColorAlpha = null;
+                            }
+
+                            outputFunction = colorStringExt.to.vec;
+                            break;
+                        }
+                    }
 
                     const isIntLiteral = selectedText.startsWith('0x');
 
@@ -164,7 +249,12 @@ export function activate(context: vscode.ExtensionContext) {
 
             runScript(getColorPickerScript(selectedColorValue)).then((rtn) => {
                 editor.edit(editBuilder => {
-                    let color = colorConvert.apple[selectedColorModel](rtn);
+                    let color;
+                    if (selectedColorModel === 'vec') {
+                        color = colorConvertAppleVec(rtn);
+                    } else {
+                        color = colorConvert.apple[selectedColorModel](rtn);
+                    }
                     editBuilder.replace(replaceTarget, outputFunction([color[0], color[1], color[2], selectedColorAlpha]));
                 });
             }).catch((err) => {


### PR DESCRIPTION
The extension doesn't support float colors in range from 0.0 to 1.0.
I wanted this for my shader coding so I added a support for it.

Colors like `vec3(0.1, 0.2, 0.3)` or `vec4(0.1, 0.2, 0.3, 0.4)`

The code probably needs some clean up, but I'm not a TypeScript developer so I don't know much about it.